### PR TITLE
#35642 Adding Shotgun Panel to all engine in Multiroot Config

### DIFF
--- a/env/asset_step.yml
+++ b/env/asset_step.yml
@@ -253,6 +253,28 @@ engines:
         template_work: max_asset_work
         template_work_area: asset_work_area_max
         version_compare_ignore_fields: []
+      tk-multi-shotgunpanel:
+        location:
+          version: v1.2.5
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+        actions_hook: '{self}/general_actions.py'
+        action_mappings:
+          PublishedFile:
+          - actions:
+            - publish_clipboard
+            filters: {}
+          Task:
+          - actions:
+            - assign_task
+            - task_to_ip
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
     compatibility_dialog_min_version: 2017
     debug_logging: false
     location:
@@ -366,8 +388,19 @@ engines:
           type: app_store
           name: tk-multi-shotgunpanel
         action_mappings:
+          PublishedFile:
+          - actions:
+            - publish_clipboard
+            filters: {}
           Task:
-          - actions: [assign_task, task_to_ip]
+          - actions:
+            - assign_task
+            - task_to_ip
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
             filters: {}
         actions_hook: '{self}/general_actions.py'
         shotgun_fields_hook: '{self}/shotgun_fields.py'
@@ -565,6 +598,28 @@ engines:
         template_work:
         template_work_area:
         version_compare_ignore_fields: []
+      tk-multi-shotgunpanel:
+        location:
+          version: v1.2.5
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+        actions_hook: '{self}/general_actions.py'
+        action_mappings:
+          PublishedFile:
+          - actions:
+            - publish_clipboard
+            filters: {}
+          Task:
+          - actions:
+            - assign_task
+            - task_to_ip
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
     compatibility_dialog_min_version: 2
     debug_logging: false
     location:
@@ -835,6 +890,28 @@ engines:
         template_work: mobu_asset_work
         template_work_area: asset_work_area_mobu
         version_compare_ignore_fields: []
+      tk-multi-shotgunpanel:
+        location:
+          version: v1.2.5
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+        actions_hook: '{self}/general_actions.py'
+        action_mappings:
+          PublishedFile:
+          - actions:
+            - publish_clipboard
+            filters: {}
+          Task:
+          - actions:
+            - assign_task
+            - task_to_ip
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
     debug_logging: false
     location:
       version: v0.3.1
@@ -1239,6 +1316,27 @@ engines:
         menu_name: Load
         publish_filters: []
         title_name: Loader
+      tk-multi-shotgunpanel:
+        action_mappings:
+          PublishedFile:
+          - actions: [read_node]
+            filters: {published_file_type: Rendered Image}
+          - actions: [script_import]
+            filters: {published_file_type: Nuke Script}
+          Task:
+          - actions: [assign_task, task_to_ip]
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
+        actions_hook: '{self}/general_actions.py:{self}/tk-nuke_actions.py'
+        location:
+          version: v1.2.5
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
     bin_context_menu:
     - {app_instance: tk-multi-workfiles2, keep_in_menu: false, name: File Save...,
       requires_selection: true}
@@ -1367,6 +1465,28 @@ engines:
         template_work: photoshop_asset_work
         template_work_area: asset_work_area_photoshop
         version_compare_ignore_fields: []
+      tk-multi-shotgunpanel:
+        location:
+          version: v1.2.5
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+        actions_hook: '{self}/general_actions.py'
+        action_mappings:
+          PublishedFile:
+          - actions:
+            - publish_clipboard
+            filters: {}
+          Task:
+          - actions:
+            - assign_task
+            - task_to_ip
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
     debug_logging: false
     location:
       version: v0.3.3
@@ -1467,6 +1587,28 @@ engines:
         template_work: softimage_asset_work
         template_work_area: asset_work_area_softimage
         version_compare_ignore_fields: []
+      tk-multi-shotgunpanel:
+        location:
+          version: v1.2.5
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+        actions_hook: '{self}/general_actions.py'
+        action_mappings:
+          PublishedFile:
+          - actions:
+            - publish_clipboard
+            filters: {}
+          Task:
+          - actions:
+            - assign_task
+            - task_to_ip
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
     debug_logging: false
     location:
       version: v0.3.2

--- a/env/project.yml
+++ b/env/project.yml
@@ -438,6 +438,36 @@ engines:
         template_work: hiero_project_work
         template_work_area: hiero_project_work_area
         version_compare_ignore_fields: []
+      tk-multi-shotgunpanel:
+        location:
+          version: v1.2.5
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+        actions_hook: '{self}/general_actions.py'
+        action_mappings:
+          PublishedFile:
+          - actions:
+            - publish_clipboard
+            filters: {}
+          - actions:
+            - read_node
+            filters:
+              published_file_type: Rendered Image
+          - actions:
+            - script_import
+            filters:
+              published_file_type: Nuke Script
+          Task:
+          - actions:
+            - assign_task
+            - task_to_ip
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
     bin_context_menu:
     - {app_instance: tk-multi-workfiles2, keep_in_menu: false, name: File Save...,
       requires_selection: true}

--- a/env/shot_step.yml
+++ b/env/shot_step.yml
@@ -259,6 +259,28 @@ engines:
         template_work: max_shot_work
         template_work_area: shot_work_area_max
         version_compare_ignore_fields: []
+      tk-multi-shotgunpanel:
+        location:
+          version: v1.2.5
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+        actions_hook: '{self}/general_actions.py'
+        action_mappings:
+          PublishedFile:
+          - actions:
+            - publish_clipboard
+            filters: {}
+          Task:
+          - actions:
+            - assign_task
+            - task_to_ip
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
     compatibility_dialog_min_version: 2017
     debug_logging: false
     location:
@@ -379,8 +401,19 @@ engines:
           type: app_store
           name: tk-multi-shotgunpanel
         action_mappings:
+          PublishedFile:
+          - actions:
+            - publish_clipboard
+            filters: {}
           Task:
-          - actions: [assign_task, task_to_ip]
+          - actions:
+            - assign_task
+            - task_to_ip
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
             filters: {}
         actions_hook: '{self}/general_actions.py'
         shotgun_fields_hook: '{self}/shotgun_fields.py'
@@ -727,6 +760,28 @@ engines:
         template_work: mobu_shot_work
         template_work_area: shot_work_area_mobu
         version_compare_ignore_fields: []
+      tk-multi-shotgunpanel:
+        location:
+          version: v1.2.5
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+        actions_hook: '{self}/general_actions.py'
+        action_mappings:
+          PublishedFile:
+          - actions:
+            - publish_clipboard
+            filters: {}
+          Task:
+          - actions:
+            - assign_task
+            - task_to_ip
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
     debug_logging: false
     location:
       version: v0.3.1
@@ -1161,6 +1216,27 @@ engines:
         menu_name: Load
         publish_filters: []
         title_name: Loader
+      tk-multi-shotgunpanel:
+        action_mappings:
+          PublishedFile:
+          - actions: [read_node]
+            filters: {published_file_type: Rendered Image}
+          - actions: [script_import]
+            filters: {published_file_type: Nuke Script}
+          Task:
+          - actions: [assign_task, task_to_ip]
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
+        actions_hook: '{self}/general_actions.py:{self}/tk-nuke_actions.py'
+        location:
+          version: v1.2.5
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
     bin_context_menu:
     - {app_instance: tk-multi-workfiles2, keep_in_menu: false, name: File Save...,
       requires_selection: true}
@@ -1289,6 +1365,28 @@ engines:
         template_work: photoshop_shot_work
         template_work_area: shot_work_area_photoshop
         version_compare_ignore_fields: []
+      tk-multi-shotgunpanel:
+        location:
+          version: v1.2.5
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+        actions_hook: '{self}/general_actions.py'
+        action_mappings:
+          PublishedFile:
+          - actions:
+            - publish_clipboard
+            filters: {}
+          Task:
+          - actions:
+            - assign_task
+            - task_to_ip
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
     debug_logging: false
     location:
       version: v0.3.3
@@ -1397,6 +1495,28 @@ engines:
         template_work: softimage_shot_work
         template_work_area: shot_work_area_softimage
         version_compare_ignore_fields: []
+      tk-multi-shotgunpanel:
+        location:
+          version: v1.2.5
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+        actions_hook: '{self}/general_actions.py'
+        action_mappings:
+          PublishedFile:
+          - actions:
+            - publish_clipboard
+            filters: {}
+          Task:
+          - actions:
+            - assign_task
+            - task_to_ip
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
     debug_logging: false
     location:
       version: v0.3.2


### PR DESCRIPTION
Until now only Maya, Nuke and Houdini has Shotgun Panel by default in default config.
Now we are adding it to all engines. Except for tk-3dsmax and tk-hiero where the panel is not working for now.